### PR TITLE
Prevent permission errors when unzipping archive.

### DIFF
--- a/fillMongo.sh
+++ b/fillMongo.sh
@@ -2,5 +2,5 @@
 rm -f dump.tar.gz
 rm -rf dump
 wget http://54.91.159.37/dump.tar.gz
-tar xzvf dump.tar.gz
+tar xzvf dump.tar.gz --no-same-owner
 mongorestore


### PR DESCRIPTION
Prevents permission problems when unarchiving the Mongo dump file on Mac OS X.

Fixes #13.