### PR TITLE
fix coffeescript install package name

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -4,7 +4,7 @@ sudo apt-get -y install python-software-properties git
 sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get -y update
 sudo apt-get -y install nodejs
-sudo apt-get -y install g++ make coffee
+sudo apt-get -y install g++ make coffeescript
 cd /coco
 sudo npm install
 sudo npm install -g bower


### PR DESCRIPTION
When using the provision script with the package name 'coffee' I got an error; from what I can tell the package name is coffeescript - maybe it changed?
