### PR TITLE
call fillMongo script even if not executable

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -18,4 +18,4 @@ sudo apt-get -y install ruby1.9.1 ruby1.9.1-dev
 sudo gem install sass
 npm install mongoose
 cd /vagrant
-./fillMongo.sh
+bash ./fillMongo.sh


### PR DESCRIPTION
In my clone of the Git repo the fillMongo.sh script didn't have the execute bit set. This seems like the most portable solution to ensure it gets called correctly anyway.
